### PR TITLE
Add TwoWay bindable property PageIndex

### DIFF
--- a/Example/Business/UI/Pages/MainPage.xaml
+++ b/Example/Business/UI/Pages/MainPage.xaml
@@ -5,6 +5,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pdf="clr-namespace:Maui.PDFView;assembly=Maui.PDFView"
     xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    xmlns:vms="clr-namespace:Example.Business.UI.ViewModels"
+    x:DataType="vms:MainPageViewModel"
     Title="Example">
 
     <ContentPage.Behaviors>
@@ -14,7 +16,7 @@
     <Grid RowDefinitions="Auto,*">
 
         <Grid
-            ColumnDefinitions="Auto,Auto,Auto"
+            ColumnDefinitions="Auto,Auto,Auto,Auto"
             ColumnSpacing="8"
             RowDefinitions="Auto,Auto">
 
@@ -46,10 +48,24 @@
                 Minimum="1"
                 Value="{Binding MaxZoom}" />
 
+            <Label
+                Grid.Row="0"
+                Grid.Column="2"
+                FontSize="Caption"
+                HorizontalTextAlignment="Center"
+                Text="{Binding PageNumber, StringFormat='Page number is {0}'}" />
+
+            <Stepper
+                Grid.Row="1"
+                Grid.Column="2"
+                Maximum="5"
+                Minimum="1"
+                Value="{Binding PageNumber, Mode=TwoWay}" />
+
             <Button
                 Grid.Row="0"
                 Grid.RowSpan="2"
-                Grid.Column="2"
+                Grid.Column="3"
                 Command="{Binding ChangeUriCommand}"
                 Text="ChangeUri"
                 VerticalOptions="Center" />
@@ -61,8 +77,9 @@
             IsHorizontal="{Binding IsHorizontal}"
             MaxZoom="{Binding MaxZoom}"
             PageChangedCommand="{Binding PageChangedCommand}"
+            PageNumber="{Binding PageNumber, Mode=TwoWay}"
             Uri="{Binding PdfSource}">
-
+            
             <pdf:PdfView.PageAppearance>
                 <pdf:PageAppearance
                     Margin="16"

--- a/Example/Business/UI/Pages/MainPage.xaml
+++ b/Example/Business/UI/Pages/MainPage.xaml
@@ -53,14 +53,14 @@
                 Grid.Column="2"
                 FontSize="Caption"
                 HorizontalTextAlignment="Center"
-                Text="{Binding PageNumber, StringFormat='Page number is {0}'}" />
+                Text="{Binding PageIndex, StringFormat='Page index is {0}'}" />
 
             <Stepper
                 Grid.Row="1"
                 Grid.Column="2"
-                Maximum="5"
-                Minimum="1"
-                Value="{Binding PageNumber, Mode=TwoWay}" />
+                Maximum="{Binding MaxPageIndex}"
+                Minimum="0"
+                Value="{Binding PageIndex, Mode=TwoWay}" />
 
             <Button
                 Grid.Row="0"
@@ -77,7 +77,7 @@
             IsHorizontal="{Binding IsHorizontal}"
             MaxZoom="{Binding MaxZoom}"
             PageChangedCommand="{Binding PageChangedCommand}"
-	        PageNumber="{Binding PageNumber, Mode=TwoWay}"
+	        PageIndex="{Binding PageIndex, Mode=TwoWay}"
             Uri="{Binding PdfSource}"/>
         
         <Label 

--- a/Example/Business/UI/Pages/MainPage.xaml
+++ b/Example/Business/UI/Pages/MainPage.xaml
@@ -15,62 +15,65 @@
 
     <Grid RowDefinitions="Auto,*">
 
-        <Grid
-            ColumnDefinitions="Auto,Auto,Auto,Auto"
-            ColumnSpacing="8"
-            RowDefinitions="Auto,Auto">
-
-            <Label
-                Grid.Row="0"
-                Grid.Column="0"
-                FontSize="Caption"
-                HorizontalTextAlignment="Center"
-                Text="Horizontal"
-                VerticalOptions="Center" />
-
-            <CheckBox
-                Grid.Row="1"
-                Grid.Column="0"
-                IsChecked="{Binding IsHorizontal}"
-                VerticalOptions="Center" />
-
-            <Label
-                Grid.Row="0"
-                Grid.Column="1"
-                FontSize="Caption"
-                HorizontalTextAlignment="Center"
-                Text="{Binding MaxZoom, StringFormat='Max zoom is {0}'}" />
-
-            <Stepper
-                Grid.Row="1"
-                Grid.Column="1"
-                Maximum="5"
-                Minimum="1"
-                Value="{Binding MaxZoom}" />
-
-            <Label
-                Grid.Row="0"
-                Grid.Column="2"
-                FontSize="Caption"
-                HorizontalTextAlignment="Center"
-                Text="{Binding PageIndex, StringFormat='Page index is {0}'}" />
-
-            <Stepper
-                Grid.Row="1"
-                Grid.Column="2"
-                Maximum="{Binding MaxPageIndex}"
-                Minimum="0"
-                Value="{Binding PageIndex, Mode=TwoWay}" />
-
-            <Button
-                Grid.Row="0"
-                Grid.RowSpan="2"
-                Grid.Column="3"
-                Command="{Binding ChangeUriCommand}"
-                Text="ChangeUri"
-                VerticalOptions="Center" />
-
-        </Grid>
+        <ScrollView Orientation="Horizontal">
+            <Grid
+                ColumnDefinitions="Auto,Auto,Auto,Auto"
+                ColumnSpacing="8"
+                RowDefinitions="Auto,Auto">
+    
+                <Label
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    FontSize="Caption"
+                    HorizontalTextAlignment="Center"
+                    Text="Horizontal"
+                    VerticalOptions="Center" />
+    
+                <CheckBox
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    IsChecked="{Binding IsHorizontal}"
+                    VerticalOptions="Center" />
+    
+                <Label
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    FontSize="Caption"
+                    HorizontalTextAlignment="Center"
+                    Text="{Binding MaxZoom, StringFormat='Max zoom is {0}'}" />
+    
+                <Stepper
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Maximum="5"
+                    Minimum="1"
+                    Value="{Binding MaxZoom}" />
+    
+                <Label
+                    Grid.Row="0"
+                    Grid.Column="2"
+                    FontSize="Caption"
+                    HorizontalTextAlignment="Center"
+                    Text="{Binding PageIndex, StringFormat='Page index is {0}'}" />
+    
+                <Stepper
+                    Grid.Row="1"
+                    Grid.Column="2"
+                    Maximum="{Binding MaxPageIndex}"
+                    Minimum="0"
+                    Value="{Binding PageIndex, Mode=TwoWay}" />
+    
+                <Button
+                    Grid.Row="0"
+                    Grid.RowSpan="2"
+                    Grid.Column="3"
+                    Command="{Binding ChangeUriCommand}"
+                    Text="ChangeUri"
+                    VerticalOptions="Center" />
+    
+            </Grid>
+        </ScrollView>
+        
 
         <pdf:PdfView
             Grid.Row="1"

--- a/Example/Business/UI/ViewModels/MainPageViewModel.cs
+++ b/Example/Business/UI/ViewModels/MainPageViewModel.cs
@@ -15,7 +15,8 @@ namespace Example.Business.UI.ViewModels
         [ObservableProperty] private bool _isHorizontal;
         [ObservableProperty] private float _maxZoom = 4;
         [ObservableProperty] private string _pagePosition;
-        [ObservableProperty] private uint _pageNumber = 1;
+        [ObservableProperty] private uint _pageIndex = 0;
+        [ObservableProperty] private uint _maxPageIndex = uint.MaxValue;
 
         [RelayCommand] private void Appearing()
         {
@@ -27,8 +28,18 @@ namespace Example.Business.UI.ViewModels
             PdfSource = _repository.GetPdfSource();
         }
 
-        [RelayCommand] private void PageChanged(PageChangedEventArgs args)
+        //private bool IsPageChangedExcutable() => false;
+        //[RelayCommand(CanExecute = nameof(IsPageChangedExcutable))]
+        //private void PageChanged(PageChangedEventArgs args)
+        //{
+        //    PagePosition = $"{args.CurrentPage} of {args.TotalPages}";
+        //    Debug.WriteLine($"Current page: {args.CurrentPage} of {args.TotalPages}");
+        //}
+
+        [RelayCommand]
+        private void PageChanged(PageChangedEventArgs args)
         {
+            MaxPageIndex = (uint)args.TotalPages - 1;
             PagePosition = $"{args.CurrentPage} of {args.TotalPages}";
             Debug.WriteLine($"Current page: {args.CurrentPage} of {args.TotalPages}");
         }

--- a/Example/Business/UI/ViewModels/MainPageViewModel.cs
+++ b/Example/Business/UI/ViewModels/MainPageViewModel.cs
@@ -14,6 +14,7 @@ namespace Example.Business.UI.ViewModels
         [ObservableProperty] private string _pdfSource;
         [ObservableProperty] private bool _isHorizontal;
         [ObservableProperty] private float _maxZoom = 4;
+        [ObservableProperty] private uint _pageNumber = 1;
 
         [RelayCommand] private void Appearing()
         {
@@ -29,5 +30,6 @@ namespace Example.Business.UI.ViewModels
         {
             Debug.WriteLine($"Current page: {args.CurrentPage} of {args.TotalPages}");
         }
+
     }
 }

--- a/Example/Business/UI/ViewModels/MainPageViewModel.cs
+++ b/Example/Business/UI/ViewModels/MainPageViewModel.cs
@@ -28,16 +28,7 @@ namespace Example.Business.UI.ViewModels
             PdfSource = _repository.GetPdfSource();
         }
 
-        //private bool IsPageChangedExcutable() => false;
-        //[RelayCommand(CanExecute = nameof(IsPageChangedExcutable))]
-        //private void PageChanged(PageChangedEventArgs args)
-        //{
-        //    PagePosition = $"{args.CurrentPage} of {args.TotalPages}";
-        //    Debug.WriteLine($"Current page: {args.CurrentPage} of {args.TotalPages}");
-        //}
-
-        [RelayCommand]
-        private void PageChanged(PageChangedEventArgs args)
+        [RelayCommand] private void PageChanged(PageChangedEventArgs args)
         {
             MaxPageIndex = (uint)args.TotalPages - 1;
             PagePosition = $"{args.CurrentPage} of {args.TotalPages}";

--- a/Maui.PDFView/Events/PageChangedEventArgs.cs
+++ b/Maui.PDFView/Events/PageChangedEventArgs.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Maui.PDFView.Events
 {
     public class PageChangedEventArgs

--- a/Maui.PDFView/IPdfView.cs
+++ b/Maui.PDFView/IPdfView.cs
@@ -8,6 +8,8 @@ namespace Maui.PDFView
         bool IsHorizontal { get; set; }
         float MaxZoom { get; set; }
         PageAppearance? PageAppearance { get; set; }
+        uint PageNumber { get; set; }
+
         ICommand PageChangedCommand { get; set; }
     }
 }

--- a/Maui.PDFView/IPdfView.cs
+++ b/Maui.PDFView/IPdfView.cs
@@ -8,7 +8,7 @@ namespace Maui.PDFView
         bool IsHorizontal { get; set; }
         float MaxZoom { get; set; }
         PageAppearance? PageAppearance { get; set; }
-        uint PageNumber { get; set; }
+        uint PageIndex { get; set; }
 
         ICommand PageChangedCommand { get; set; }
     }

--- a/Maui.PDFView/PdfView.cs
+++ b/Maui.PDFView/PdfView.cs
@@ -36,8 +36,8 @@ namespace Maui.PDFView
                 declaringType: typeof(PdfView),
                 defaultValue: default(ICommand));
 
-        public static readonly BindableProperty PageNumberProperty = BindableProperty.Create(
-                propertyName: nameof(PageNumber),
+        public static readonly BindableProperty PageIndexProperty = BindableProperty.Create(
+                propertyName: nameof(PageIndex),
                 returnType: typeof(uint),
                 declaringType: typeof(PdfView),
                 defaultValue: (uint)0, defaultBindingMode: BindingMode.TwoWay);
@@ -72,10 +72,10 @@ namespace Maui.PDFView
             set => SetValue(PageChangedCommandProperty, value);
         }
 
-        public uint PageNumber
+        public uint PageIndex
         {
-            get => (uint)GetValue(PageNumberProperty);
-            set => SetValue(PageNumberProperty, value);
+            get => (uint)GetValue(PageIndexProperty);
+            set => SetValue(PageIndexProperty, value);
         }
 
         private static void OnMaxZoomPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Maui.PDFView/PdfView.cs
+++ b/Maui.PDFView/PdfView.cs
@@ -36,6 +36,12 @@ namespace Maui.PDFView
                 declaringType: typeof(PdfView),
                 defaultValue: default(ICommand));
 
+        public static readonly BindableProperty PageNumberProperty = BindableProperty.Create(
+                propertyName: nameof(PageNumber),
+                returnType: typeof(uint),
+                declaringType: typeof(PdfView),
+                defaultValue: (uint)0, defaultBindingMode: BindingMode.TwoWay);
+
         public string Uri
         {
             get => (string)GetValue(UriProperty);
@@ -64,6 +70,12 @@ namespace Maui.PDFView
         {
             get => (ICommand)GetValue(PageChangedCommandProperty);
             set => SetValue(PageChangedCommandProperty, value);
+        }
+
+        public uint PageNumber
+        {
+            get => (uint)GetValue(PageNumberProperty);
+            set => SetValue(PageNumberProperty, value);
         }
 
         private static void OnMaxZoomPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/Maui.PDFView/Platforms/Android/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/Android/PdfViewHandler.cs
@@ -28,6 +28,9 @@ namespace Maui.PDFView.Platforms.Android
         private readonly DesiredSizeHelper _sizeHelper = new();
         
         private PageAppearance? _pageAppearance;
+        
+        private bool _isScrolling;
+        private bool _isPageIndexLocked;
 
         public PdfViewHandler() : base(PropertyMapper, null)
         {
@@ -172,12 +175,9 @@ namespace Maui.PDFView.Platforms.Android
             return matrix;
         }
 
-        private bool isScrolling;
-        private bool isPageIndexLocked;
-
         private void GotoPage(uint pageIndex)
         {
-            if (isScrolling)
+            if (_isScrolling)
                 return;
 
             var layoutManager = (LinearLayoutManager)_recycleView.GetLayoutManager()!;
@@ -185,8 +185,8 @@ namespace Maui.PDFView.Platforms.Android
             if (pageIndex >= layoutManager.ItemCount)
                 return;
 
-            isPageIndexLocked = true;
-            layoutManager.ScrollToPosition((int)pageIndex);
+            _isPageIndexLocked = true;
+            layoutManager.ScrollToPositionWithOffset((int)pageIndex,1);
         }
 
         private class PdfScrollListener : RecyclerView.OnScrollListener
@@ -241,15 +241,15 @@ namespace Maui.PDFView.Platforms.Android
                 }
 
                 var newPageIndex = (uint)currentPage;
-                if (_handler.isPageIndexLocked)
+                if (_handler._isPageIndexLocked)
                 {
-                    _handler.isPageIndexLocked = false;
+                    _handler._isPageIndexLocked = false;
                 }
                 else if (_handler.VirtualView.PageIndex != newPageIndex)
                 {
-                    _handler.isScrolling = true;
+                    _handler._isScrolling = true;
                     _handler.VirtualView.PageIndex = newPageIndex;
-                    _handler.isScrolling = false;
+                    _handler._isScrolling = false;
                 }
 
                 if (_handler.VirtualView.PageChangedCommand?.CanExecute(null) == true)

--- a/Maui.PDFView/Platforms/Android/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/Android/PdfViewHandler.cs
@@ -172,8 +172,13 @@ namespace Maui.PDFView.Platforms.Android
             return matrix;
         }
 
+        private bool isScrolling;
+
         private void GotoPage(uint pageNumber)
         {
+            if (isScrolling)
+                return;
+
             var layoutManager = (LinearLayoutManager)_recycleView.GetLayoutManager()!;
 
             if (pageNumber == 0 || layoutManager.ItemCount <= pageNumber - 1)
@@ -237,7 +242,11 @@ namespace Maui.PDFView.Platforms.Android
                 {
                     var newPage = (uint)currentPage + 1;
                     if (_handler.VirtualView.PageNumber != newPage)
+                    {
+                        _handler.isScrolling = true;
                         _handler.VirtualView.PageNumber = newPage;
+                        _handler.isScrolling = false;
+                    }
 
                     if (_handler.VirtualView.PageChangedCommand?.CanExecute(null) == true)
                         // Execute the command if available

--- a/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
@@ -15,7 +15,7 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             [nameof(IPdfView.IsHorizontal)] = MapIsHorizontal,
             [nameof(IPdfView.MaxZoom)] = MapMaxZoom,
             [nameof(IPdfView.PageAppearance)] = MapPageAppearance,
-            [nameof(IPdfView.PageNumber)] = MapPageNumber,
+            [nameof(IPdfView.PageIndex)] = MapPageIndex,
         };
 
         private string _fileName;
@@ -53,9 +53,9 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             SetPageAppearance(handler, appearance);
         }
 
-        static void MapPageNumber(PdfViewHandler handler, IPdfView pdfView)
+        static void MapPageIndex(PdfViewHandler handler, IPdfView pdfView)
         {
-            handler.GotoPage(pdfView.PageNumber);
+            handler.GotoPage(pdfView.PageIndex);
         }
 
         private static void SetPageAppearance(PdfViewHandler handler, PageAppearance appearance)
@@ -126,7 +126,7 @@ namespace Maui.PDFView.Platforms.MacCatalyst
 
         private bool isScrolling;
 
-        private void GotoPage(uint pageNumber)
+        private void GotoPage(uint pageIndex)
         {
             if (isScrolling)
                 return;
@@ -135,10 +135,10 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             if (document is null)
                 return;
 
-            if (pageNumber == 0 || document.PageCount <= pageNumber - 1)
+            if (pageIndex == 0 || document.PageCount <= pageIndex - 1)
                 return;
 
-            var newPage = document.GetPage((nint)pageNumber - 1);
+            var newPage = document.GetPage((nint)pageIndex);
 
             if (newPage is null)
                 return;
@@ -156,18 +156,18 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             if (document is null)
                 return;
 
-            var newPage = (uint)document.GetPageIndex(currentPage) + 1;
-            if (VirtualView.PageNumber != newPage)
+            var newPageIndex = (uint)document.GetPageIndex(currentPage);
+            if (VirtualView.PageIndex != newPageIndex)
             {
                 isScrolling = true;
-                VirtualView.PageNumber = newPage;
+                VirtualView.PageIndex = newPageIndex;
                 isScrolling = false;
             }
 
             if (!(VirtualView.PageChangedCommand?.CanExecute(null) ?? false))
                 return;
 
-            VirtualView.PageChangedCommand.Execute(new PageChangedEventArgs((int)newPage, (int)document.PageCount));
+            VirtualView.PageChangedCommand.Execute(new PageChangedEventArgs((int)newPageIndex+1, (int)document.PageCount));
 
         }
 

--- a/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
@@ -124,8 +124,13 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             PlatformView.AutoScales = true;
         }
 
+        private bool isScrolling;
+
         private void GotoPage(uint pageNumber)
         {
+            if (isScrolling)
+                return;
+
             var document = PlatformView.Document;
             if (document is null)
                 return;
@@ -153,7 +158,11 @@ namespace Maui.PDFView.Platforms.MacCatalyst
 
             var newPage = (uint)document.GetPageIndex(currentPage) + 1;
             if (VirtualView.PageNumber != newPage)
+            {
+                isScrolling = true;
                 VirtualView.PageNumber = newPage;
+                isScrolling = false;
+            }
 
             if (!(VirtualView.PageChangedCommand?.CanExecute(null) ?? false))
                 return;

--- a/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
@@ -135,7 +135,7 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             if (document is null)
                 return;
 
-            if (pageIndex == 0 || document.PageCount <= pageIndex - 1)
+            if (pageIndex >= document.PageCount)
                 return;
 
             var newPage = document.GetPage((nint)pageIndex);

--- a/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/MacCatalyst/PdfViewHandler.cs
@@ -21,6 +21,8 @@ namespace Maui.PDFView.Platforms.MacCatalyst
         private string _fileName;
         private PageAppearance _appearance = new();
         private readonly DesiredSizeHelper _sizeHelper = new();
+        
+        private bool _isScrolling;
 
         public PdfViewHandler() : base(PropertyMapper, null)
         {
@@ -124,11 +126,9 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             PlatformView.AutoScales = true;
         }
 
-        private bool isScrolling;
-
         private void GotoPage(uint pageIndex)
         {
-            if (isScrolling)
+            if (_isScrolling)
                 return;
 
             var document = PlatformView.Document;
@@ -159,9 +159,9 @@ namespace Maui.PDFView.Platforms.MacCatalyst
             var newPageIndex = (uint)document.GetPageIndex(currentPage);
             if (VirtualView.PageIndex != newPageIndex)
             {
-                isScrolling = true;
+                _isScrolling = true;
                 VirtualView.PageIndex = newPageIndex;
-                isScrolling = false;
+                _isScrolling = false;
             }
 
             if (!(VirtualView.PageChangedCommand?.CanExecute(null) ?? false))

--- a/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
@@ -125,6 +125,9 @@ namespace Maui.PDFView.Platforms.Windows
                     _stack.Children.Add(MakePage(bitmap, _pageAppearance));
                 }
             }
+
+            //  Reset page index
+            VirtualView.PageIndex = 0;
         }
 
         private UIElement MakePage(BitmapImage image, PageAppearance pageAppearance)

--- a/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
@@ -226,23 +226,20 @@ namespace Maui.PDFView.Platforms.Windows
             
             }
 
-            if (currentPage >= 0)
+            var newPageIndex = (uint)currentPage;
+            if (isPageIndexLocked)
             {
-                var newPageIndex = (uint)currentPage;
-                if (isPageIndexLocked)
-                {
-                    isPageIndexLocked = false;
-                }
-                else if (VirtualView.PageIndex != newPageIndex)
-                {
-                    isScrolling = true;
-                    VirtualView.PageIndex = newPageIndex;
-                    isScrolling = false;
-                }
-
-                if (VirtualView.PageChangedCommand?.CanExecute(null) == true)
-                    VirtualView.PageChangedCommand.Execute(new PageChangedEventArgs(currentPage + 1, layout.Children.Count));
+                isPageIndexLocked = false;
             }
+            else if (VirtualView.PageIndex != newPageIndex)
+            {
+                isScrolling = true;
+                VirtualView.PageIndex = newPageIndex;
+                isScrolling = false;
+            }
+
+            if (VirtualView.PageChangedCommand?.CanExecute(null) == true)
+                VirtualView.PageChangedCommand.Execute(new PageChangedEventArgs(currentPage + 1, layout.Children.Count));
         }
     }
 }

--- a/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
@@ -30,6 +30,9 @@ namespace Maui.PDFView.Platforms.Windows
         private string _fileName;
 
         private PageAppearance _pageAppearance = new PageAppearance();
+        
+        private bool _isScrolling;
+        private bool _isPageIndexLocked;
 
         public PdfViewHandler() : base(PropertyMapper, null)
         {
@@ -160,12 +163,11 @@ namespace Maui.PDFView.Platforms.Windows
             target.Translation += new Vector3(0, 0, ZDepth);
         }
 
-        private bool isScrolling;
-        private bool isPageIndexLocked;
+       
 
         private void GotoPage(uint pageIndex)
         {
-            if (isScrolling)
+            if (_isScrolling)
                 return;
 
             var layout = (StackPanel)_scrollViewer.Content;
@@ -178,7 +180,7 @@ namespace Maui.PDFView.Platforms.Windows
                 var transform = child.TransformToVisual(_scrollViewer);
                 var position = transform.TransformBounds(new(0, 0, child.ActualWidth, child.ActualHeight));
 
-                isPageIndexLocked = true;
+                _isPageIndexLocked = true;
                 if (_stack.Orientation == Orientation.Vertical)
                     _scrollViewer.ScrollToVerticalOffset(_scrollViewer.ZoomFactor*child.ActualOffset.Y);
                 else
@@ -227,15 +229,15 @@ namespace Maui.PDFView.Platforms.Windows
             }
 
             var newPageIndex = (uint)currentPage;
-            if (isPageIndexLocked)
+            if (_isPageIndexLocked)
             {
-                isPageIndexLocked = false;
+                _isPageIndexLocked = false;
             }
             else if (VirtualView.PageIndex != newPageIndex)
             {
-                isScrolling = true;
+                _isScrolling = true;
                 VirtualView.PageIndex = newPageIndex;
-                isScrolling = false;
+                _isScrolling = false;
             }
 
             if (VirtualView.PageChangedCommand?.CanExecute(null) == true)

--- a/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/Windows/PdfViewHandler.cs
@@ -159,8 +159,13 @@ namespace Maui.PDFView.Platforms.Windows
             target.Translation += new Vector3(0, 0, ZDepth);
         }
 
+        private bool isScrolling;
+
         private void GotoPage(uint pageNumber)
         {
+            if (isScrolling)
+                return;
+
             var layout = (StackPanel)_scrollViewer.Content;
             if (pageNumber == 0 || layout.Children.Count <= pageNumber - 1)
                 return;
@@ -171,8 +176,7 @@ namespace Maui.PDFView.Platforms.Windows
                 var transform = child.TransformToVisual(_scrollViewer);
                 var position = transform.TransformBounds(new(0, 0, child.ActualWidth, child.ActualHeight));
 
-                //this.pageNumber = pageNumber;
-                _scrollViewer.ChangeView(child.ActualOffset.X, child.ActualOffset.Y, 1, true);
+                _scrollViewer.ScrollToVerticalOffset(_scrollViewer.ZoomFactor*child.ActualOffset.Y);
             }
         }
 
@@ -220,7 +224,11 @@ namespace Maui.PDFView.Platforms.Windows
             {
                 var newPage = (uint)currentPage + 1;
                 if (VirtualView.PageNumber != newPage)
+                {
+                    isScrolling = true;
                     VirtualView.PageNumber = newPage;
+                    isScrolling = false;
+                }
 
                 if (VirtualView.PageChangedCommand?.CanExecute(null) == true)
                     VirtualView.PageChangedCommand.Execute(new PageChangedEventArgs(currentPage + 1, layout.Children.Count));

--- a/Maui.PDFView/Platforms/iOS/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/iOS/PdfViewHandler.cs
@@ -17,7 +17,7 @@ namespace Maui.PDFView.Platforms.iOS
             [nameof(IPdfView.IsHorizontal)] = MapIsHorizontal,
             [nameof(IPdfView.MaxZoom)] = MapMaxZoom,
             [nameof(IPdfView.PageAppearance)] = MapPageAppearance,
-            [nameof(IPdfView.PageNumber)] = MapPageNumber,
+            [nameof(IPdfView.PageIndex)] = MapPageIndex,
         };
 
         private string _fileName;
@@ -55,9 +55,9 @@ namespace Maui.PDFView.Platforms.iOS
             SetPageAppearance(handler, appearance);
         }
 
-        static void MapPageNumber(PdfViewHandler handler, IPdfView pdfView)
+        static void MapPageIndex(PdfViewHandler handler, IPdfView pdfView)
         {
-            handler.GotoPage(pdfView.PageNumber);
+            handler.GotoPage(pdfView.PageIndex);
         }
 
         private static void SetPageAppearance(PdfViewHandler handler, PageAppearance appearance)
@@ -128,7 +128,7 @@ namespace Maui.PDFView.Platforms.iOS
 
         private bool isScrolling;
 
-        private void GotoPage(uint pageNumber)
+        private void GotoPage(uint pageIndex)
         {
             if (isScrolling)
                 return;
@@ -137,10 +137,10 @@ namespace Maui.PDFView.Platforms.iOS
             if (document is null)
                 return;
 
-            if (pageNumber == 0 || document.PageCount <= pageNumber - 1)
+            if (pageIndex >= document.PageCount)
                 return;
 
-            var newPage = document.GetPage((nint)pageNumber - 1);
+            var newPage = document.GetPage((nint)pageIndex);
 
             if (newPage is null)
                 return;
@@ -158,18 +158,18 @@ namespace Maui.PDFView.Platforms.iOS
             if (document is null)
                 return;
 
-            var newPage = (uint)document.GetPageIndex(currentPage) + 1;
-            if (VirtualView.PageNumber != newPage)
+            var newPageIndex = (uint)document.GetPageIndex(currentPage);
+            if (VirtualView.PageIndex != newPageIndex)
             {
                 isScrolling = true;
-                VirtualView.PageNumber = newPage;
+                VirtualView.PageIndex = newPageIndex;
                 isScrolling = false;
             }
                 
             if (!(VirtualView.PageChangedCommand?.CanExecute(null) ?? false))
                 return;
 
-            VirtualView.PageChangedCommand.Execute(new PageChangedEventArgs((int)newPage, (int)document.PageCount));
+            VirtualView.PageChangedCommand.Execute(new PageChangedEventArgs((int)newPageIndex+1, (int)document.PageCount));
         }
         
         private void CropPages(PdfKit.PdfDocument pdfdoc, Thickness cropBounds)

--- a/Maui.PDFView/Platforms/iOS/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/iOS/PdfViewHandler.cs
@@ -23,6 +23,8 @@ namespace Maui.PDFView.Platforms.iOS
         private string _fileName;
         private PageAppearance _appearance = new();
         private readonly DesiredSizeHelper _sizeHelper = new();
+        
+        private bool _isScrolling;
 
         public PdfViewHandler() : base(PropertyMapper, null)
         {
@@ -126,11 +128,9 @@ namespace Maui.PDFView.Platforms.iOS
             PlatformView.AutoScales = true;
         }
 
-        private bool isScrolling;
-
         private void GotoPage(uint pageIndex)
         {
-            if (isScrolling)
+            if (_isScrolling)
                 return;
 
             var document = PlatformView.Document;
@@ -161,9 +161,9 @@ namespace Maui.PDFView.Platforms.iOS
             var newPageIndex = (uint)document.GetPageIndex(currentPage);
             if (VirtualView.PageIndex != newPageIndex)
             {
-                isScrolling = true;
+                _isScrolling = true;
                 VirtualView.PageIndex = newPageIndex;
-                isScrolling = false;
+                _isScrolling = false;
             }
                 
             if (!(VirtualView.PageChangedCommand?.CanExecute(null) ?? false))

--- a/Maui.PDFView/Platforms/iOS/PdfViewHandler.cs
+++ b/Maui.PDFView/Platforms/iOS/PdfViewHandler.cs
@@ -126,8 +126,13 @@ namespace Maui.PDFView.Platforms.iOS
             PlatformView.AutoScales = true;
         }
 
+        private bool isScrolling;
+
         private void GotoPage(uint pageNumber)
         {
+            if (isScrolling)
+                return;
+
             var document = PlatformView.Document;
             if (document is null)
                 return;
@@ -155,7 +160,11 @@ namespace Maui.PDFView.Platforms.iOS
 
             var newPage = (uint)document.GetPageIndex(currentPage) + 1;
             if (VirtualView.PageNumber != newPage)
+            {
+                isScrolling = true;
                 VirtualView.PageNumber = newPage;
+                isScrolling = false;
+            }
                 
             if (!(VirtualView.PageChangedCommand?.CanExecute(null) ?? false))
                 return;


### PR DESCRIPTION
Added property **PageNumber** that can be bound with Mode=TwoWay; so it allows to keep updated the page number, but also go to an specific page.

The example was modified to show the usage of the **PageNumber** property using Label and Stepper controls:

```
<Label
    Grid.Row="0"
    Grid.Column="2"
    FontSize="Caption"
    HorizontalTextAlignment="Center"
    Text="{Binding PageNumber, StringFormat='Page number is {0}'}" />

<Stepper
    Grid.Row="1"
    Grid.Column="2"
    Maximum="5"
    Minimum="1"
    Value="{Binding PageNumber, Mode=TwoWay}" />
```

```
<pdf:PdfView
    Grid.Row="1"
    IsHorizontal="{Binding IsHorizontal}"
    MaxZoom="{Binding MaxZoom}"
    PageChangedCommand="{Binding PageChangedCommand}"
    PageNumber="{Binding PageNumber, Mode=TwoWay}"
    Uri="{Binding PdfSource}"/>
```

